### PR TITLE
Cora: Instrument Catalog Generator (start)

### DIFF
--- a/catalogs/instrument_catalog.sample.json
+++ b/catalogs/instrument_catalog.sample.json
@@ -1,0 +1,13 @@
+{
+  "DAQ-PCIe": 977.17,
+  "Oscilloscope-4ch": 86.27,
+  "Spectrum-Analyzer": 448.79,
+  "Thermocouples-Set": 373.66,
+  "Vibe-Fixture": 1117.88,
+  "Pressure-Rig": 1031.21,
+  "Power-Supply-600W": 1343.66,
+  "Torque-Wrench": 176.06,
+  "RF-Preamp": 661.79,
+  "CAN-Interface": 93.21,
+  "Flight-Computer-DevBoard": 367.03
+}

--- a/src/cora_distance.py
+++ b/src/cora_distance.py
@@ -1,0 +1,22 @@
+#!/coramb2/bin/env python3
+# Cora: instrument catalog generator (minimal)
+import random, json
+
+# List of Fake Instruments and their Costs
+def generate_instrument_catalog(seed: int = 42):
+    random.seed(seed)
+    instruments = [
+        "DAQ-PCIe", "Oscilloscope-4ch", "Spectrum-Analyzer",
+        "Thermocouples-Set", "Vibe-Fixture", "Pressure-Rig",
+        "Power-Supply-600W", "Torque-Wrench", "RF-Preamp",
+        "CAN-Interface", "Flight-Computer-DevBoard"
+    ]
+   # Makes a Dictionary
+   # (key = instrument name, value = cost)
+   # Each cost is randomly generated between $50 - 1500
+    return {name: round(random.uniform(50.0, 1500.0), 2) for name in instruments}
+
+   # Testing
+if __name__ == "__main__":
+    catalog = generate_instrument_catalog()
+    print(json.dumps(catalog, indent=2))


### PR DESCRIPTION
Generates a list of random costs for test instruments

- DAQ-PCIe: Data Acquisition card, collects sensor data (voltages, strain gauges, accelerometers during vibration).
- Oscilloscope-4ch: For monitoring electrical signals during tests.
- Spectrum Analyzer: For EMI/EMC tests (checking radio frequency emissions).
- Thermocouples-Set: Temperature sensors used during thermal vac testing.
- Vibe-Fixture: Mechanical fixture that holds the spacecraft onto the shaker table.
- Pressure-Rig: Pumps/valves used during pressure/leak tests.
- Power-Supply-600W: Provides power to the spacecraft during ground testing.
- Torque-Wrench: Mechanical tool to assemble/disassemble components to spec during integration.
- RF-Preamp: Radio frequency preamplifier for weak-signal EMI/EMC measurements.
- CAN-Interface: Controller Area Network interface, for spacecraft bus communications during tests.
- Flight-Computer-DevBoard: A bench-top copy of the spacecraft’s flight computer, used for software/hardware-in-loop testing.